### PR TITLE
Use correct mechanism to disable auto-sizes CSS fix

### DIFF
--- a/src/Modules/Performance.php
+++ b/src/Modules/Performance.php
@@ -26,7 +26,7 @@ class Performance extends Module
         remove_action('wp_head', 'rsd_link');
         remove_action('wp_head', 'wp_oembed_add_discovery_links');
         remove_action('wp_head', 'wp_custom_css_cb', 101);
-        remove_action('wp_head', 'wp_print_auto_sizes_contain_css_fix', 1);
+        add_filter('wp_img_tag_add_auto_sizes', '__return_false');
 
         // Disable emojis
         remove_action('wp_head', 'print_emoji_detection_script', 7);


### PR DESCRIPTION
As per https://core.trac.wordpress.org/ticket/62731 we may be using a different function that hooks into `wp_enqueue_scripts` instead of `wp_head`. There is also a `wp_img_tag_add_auto_sizes` filter specifically for the purpose of disabling this style, so it should be used instead.